### PR TITLE
feat: 外部参照できるようにパッケージ名を変更

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"github.com/polidog/go-music"
+)
+
+func main() {
+	res, err := music.Track()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("player_state:", res.PlayerState)
+
+	fmt.Println("----------track-----------")
+	fmt.Println("Name:", res.Track.Name)
+	fmt.Println("Album:", res.Track.Album)
+	fmt.Println("Artist:", res.Track.Artist)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-music
+module github.com/polidog/go-music
 
 go 1.14
 

--- a/music.go
+++ b/music.go
@@ -3,7 +3,8 @@ package music
 import (
 	"encoding/json"
 	"fmt"
-	"go-music/script"
+
+	"github.com/polidog/go-music/script"
 )
 
 // Track is 再生しているトラック情報

--- a/script/script.go
+++ b/script/script.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "go-music/script/statik"
+	_ "github.com/polidog/go-music/script/statik"
 
 	"github.com/rakyll/statik/fs"
 )


### PR DESCRIPTION
READMEにあるように「github.com/polidog/go-music」をインポートし、
外部のプログラムから参照を行えるようにする場合、
GoModulesではパッケージ名自体を「github.com/polidog/go-music」にしておく必要があります。

またmusic.goが使用しているscriptも上記のパッケージ名、
script.goで使用しているstatikのパッケージ名もモジュールの絶対パスで記述します。

これにより、READMEにあるようなプログラムを他人がgo getで作成することが可能になります。
※逆にいうとREADMEにあるパッケージを「go-music」にして、
　ローカルのプログラムとして使用するのであればこのコミットのマージは必要ありません

参考としてexamplesに同等のコードを記述しました。

GoModulesではexamplesのようなディレクトリで実行を行うと、
上位のgo.modを検索し、見つかった場合はそこを元にモジュール検索してくれます。