### PR TITLE
fix: typo

### DIFF
--- a/script/script_windows.go
+++ b/script/script_windows.go
@@ -16,6 +16,6 @@ type WindowsScript struct {
 }
 
 // Exec call osascript
-func (a AppleScript) Exec(command string) ([]byte, error) {
+func (a WindowsScript) Exec(command string) ([]byte, error) {
 	return exec.Command("cscript -e", a.path, command).Output()
 }


### PR DESCRIPTION
Windowsでのビルドエラーを修正

※よく見たらREADMEの「music.Track()」自体がまだないことに気づく